### PR TITLE
Allow older Symfony EventDispatcher version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "cweagans/composer-patches": "^1.6",
     "bomoko/mysql-cnf-parser": "^0.0.2",
     "fzaninotto/faker": "^1.7",
-    "symfony/event-dispatcher": "^4.1"
+    "symfony/event-dispatcher": "~3.4|~4.0"
   },
   "license": "GPL-2.0-or-later",
   "authors": [


### PR DESCRIPTION
GDPR Dump depends on the Symfony EventDispatcher component and so does Drupal core. While the former sets the newest, ^4.1 as the required version, the latter [still uses ~3.4.0](https://github.com/drupal/core/blob/8.6.x/composer.json#L24), which creates a compatibility issue when when we wish to directly include GDPR Dump in our Drupal projects.

As there were no API changes in the EventDispatcher component between Symfony 3 and 4, can we please change the version constraint to remove this issue, and allow both the latest ~3.4 and ~4.0 versions? This is how Symfony components set their dependencies to other components where there is compatibility. An example: https://github.com/symfony/event-dispatcher/blob/v4.1.3/composer.json#L21.