### PR TITLE
GDPR replacements from JSON file

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Where *formatterType* is one of the following
 
 This will replace the given column's value with Faker output.
 
+You can also save replacements mapping to JSON file and use it with `--gdpr-replacements-file` option.
+
 ## Use with drush
 
 As this mimicks mysqldump, it can be use with drush, backup_migrate and any tool that uses mysqldump.

--- a/src/Command/DumpCommand.php
+++ b/src/Command/DumpCommand.php
@@ -354,7 +354,6 @@ class DumpCommand extends Command
             ] + [
                 'gdpr-expressions' => null,
                 'gdpr-replacements' => null,
-                'gdpr-replacements-file' => null,
                 'debug-sql' => false,
             ];
     }

--- a/src/Command/DumpCommand.php
+++ b/src/Command/DumpCommand.php
@@ -105,6 +105,8 @@ class DumpCommand extends Command
                 'A json of gdpr sql-expressions keyed by table and column.')
             ->addOption('gdpr-replacements', null, InputOption::VALUE_OPTIONAL,
                 'A json of gdpr replacement values keyed by table and column.')
+            ->addOption('gdpr-replacements-file', null, InputOption::VALUE_OPTIONAL,
+                'File that contains a json of gdpr replacement values keyed by table and column.')
             ->addOption('debug-sql', null, InputOption::VALUE_NONE,
                 'Add a comment with the dump sql.')
             // This seems NOT to work as documented.
@@ -202,6 +204,15 @@ class DumpCommand extends Command
 
         if (!empty($dumpSettings['gdpr-replacements'])) {
             $dumpSettings['gdpr-replacements'] = json_decode($dumpSettings['gdpr-replacements'],
+                true);
+            if (json_last_error()) {
+                throw new \UnexpectedValueException(sprintf('Invalid gdpr-replacements json (%s): %s',
+                    json_last_error_msg(), $dumpSettings['gdpr-replacements']));
+            }
+        }
+
+        if (!empty($dumpSettings['gdpr-replacements-file'])) {
+            $dumpSettings['gdpr-replacements'] = json_decode(file_get_contents($dumpSettings['gdpr-replacements-file']),
                 true);
             if (json_last_error()) {
                 throw new \UnexpectedValueException(sprintf('Invalid gdpr-replacements json (%s): %s',
@@ -343,6 +354,7 @@ class DumpCommand extends Command
             ] + [
                 'gdpr-expressions' => null,
                 'gdpr-replacements' => null,
+                'gdpr-replacements-file' => null,
                 'debug-sql' => false,
             ];
     }

--- a/src/MysqldumpGdpr.php
+++ b/src/MysqldumpGdpr.php
@@ -35,11 +35,6 @@ class MysqldumpGdpr extends Mysqldump
             unset($dumpSettings['gdpr-replacements']);
         }
 
-        if (array_key_exists('gdpr-replacements-file', $dumpSettings)) {
-            $this->gdprReplacements = json_decode(file_get_contents($dumpSettings['gdpr-replacements-file']),true);
-            unset($dumpSettings['gdpr-replacements-file']);
-        }
-
         if (array_key_exists('debug-sql', $dumpSettings)) {
             $this->debugSql = $dumpSettings['debug-sql'];
             unset($dumpSettings['debug-sql']);

--- a/src/MysqldumpGdpr.php
+++ b/src/MysqldumpGdpr.php
@@ -35,6 +35,11 @@ class MysqldumpGdpr extends Mysqldump
             unset($dumpSettings['gdpr-replacements']);
         }
 
+        if (array_key_exists('gdpr-replacements-file', $dumpSettings)) {
+            $this->gdprReplacements = json_decode(file_get_contents($dumpSettings['gdpr-replacements-file']),true);
+            unset($dumpSettings['gdpr-replacements-file']);
+        }
+
         if (array_key_exists('debug-sql', $dumpSettings)) {
             $this->debugSql = $dumpSettings['debug-sql'];
             unset($dumpSettings['debug-sql']);


### PR DESCRIPTION
_Reopening https://github.com/machbarmacher/gdpr-dump/pull/25 as I had to change master branch._

Editing mysql ini is a bit inconvenient so  I made an option to read those from file. 

This allows reading the GDPR replacement pattern from a JSON file using `--gdpr-replacements-file` option. You can use the same JSON structure you would for the `--gdpr-replacements` option.