### PR TITLE
Allow registration of custom transformers and pass whole event to get…

### DIFF
--- a/src/ColumnTransformer/Plugins/ClearColumnTransformer.php
+++ b/src/ColumnTransformer/Plugins/ClearColumnTransformer.php
@@ -3,6 +3,7 @@
 namespace machbarmacher\GdprDump\ColumnTransformer\Plugins;
 
 use machbarmacher\GdprDump\ColumnTransformer\ColumnTransformer;
+use machbarmacher\GdprDump\ColumnTransformer\ColumnTransformEvent;
 
 class ClearColumnTransformer extends ColumnTransformer
 {
@@ -12,7 +13,7 @@ class ClearColumnTransformer extends ColumnTransformer
         return ['clear'];
     }
 
-    public function getValue($expression)
+    public function getValue(ColumnTransformEvent $event)
     {
         return "";
     }

--- a/src/ColumnTransformer/Plugins/FakerColumnTransformer.php
+++ b/src/ColumnTransformer/Plugins/FakerColumnTransformer.php
@@ -3,8 +3,8 @@
 namespace machbarmacher\GdprDump\ColumnTransformer\Plugins;
 
 use Faker\Factory;
-use Faker\Provider\Base;
 use machbarmacher\GdprDump\ColumnTransformer\ColumnTransformer;
+use machbarmacher\GdprDump\ColumnTransformer\ColumnTransformEvent;
 
 class FakerColumnTransformer extends ColumnTransformer
 {
@@ -30,21 +30,21 @@ class FakerColumnTransformer extends ColumnTransformer
     {
         if (!isset(self::$generator)) {
             self::$generator = Factory::create();
-            foreach(self::$generator->getProviders() as $provider)
-            {
+            foreach (self::$generator->getProviders() as $provider) {
                 $clazz = new \ReflectionClass($provider);
                 $methods = $clazz->getMethods(\ReflectionMethod::IS_PUBLIC);
-                foreach($methods as $m)
-                {
-                    if(strpos($m->name, '__') === 0) continue;
+                foreach ($methods as $m) {
+                    if (strpos($m->name, '__') === 0) {
+                        continue;
+                    }
                     self::$formatterTansformerMap[$m->name] = $m->name;
                 }
             }
         }
     }
 
-    public function getValue($expression)
+    public function getValue(ColumnTransformEvent $event)
     {
-        return self::$generator->format(self::$formatterTansformerMap[$expression['formatter']]);
+        return self::$generator->format(self::$formatterTansformerMap[$event->getExpression()['formatter']]);
     }
 }


### PR DESCRIPTION
I'm making a command inside existing symfony project which creates anonymized dump and sends it over email. I needed to have custom transformers. Also one of them needed to know which table it anonymize because of password hashing. (which could be different per table). I'm using Symfony  and ORM - so I need to know table - from table I finds the Entity class, and from entity class I find the correct encoder.

```
<?php

namespace AppBundle;

use Doctrine\ORM\EntityManagerInterface;
use Doctrine\ORM\Mapping\ClassMetadata;
use machbarmacher\GdprDump\ColumnTransformer\ColumnTransformer;
use machbarmacher\GdprDump\ColumnTransformer\ColumnTransformEvent;
use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;

class SymfonyPasswordColumnTransformer extends ColumnTransformer
{
    /** @var string */
    private $plainPassword;

    /** @var EncoderFactoryInterface */
    private $encoderFactory;

    /** @var EntityManagerInterface */
    private $entityManager;

    public function __construct(
        string $plainPassword,
        EncoderFactoryInterface $encoderFactory,
        EntityManagerInterface $entityManager
    ) {
        $this->plainPassword = $plainPassword;
        $this->encoderFactory = $encoderFactory;
        $this->entityManager = $entityManager;
    }

    public function getValue(ColumnTransformEvent $event)
    {
        $table = $event->getTable();

        foreach ($this->entityManager->getMetadataFactory()->getAllMetadata() as $metadata) {
            /** @var $metadata ClassMetadata */
            if ($table === $metadata->getTableName()) {
                $encoder = $this->encoderFactory->getEncoder($metadata->getReflectionClass()->getName());

                return $encoder->encodePassword($this->plainPassword, null);
            }
        }
        throw new \LogicException('Table '.$table.' not found in supported entities');
    }

    protected function getSupportedFormatters()
    {
        return ['symfony_password_transformer'];
    }
}
```