### PR TITLE
Make it possible to install the tool on systems with PHP 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "symfony/console": "^3.0",
     "ifsnop/mysqldump-php": "dev-master",
     "cweagans/composer-patches": "^1.6",
-    "bomoko/mysql-cnf-parser": "^0.0.2",
+    "bomoko/mysql-cnf-parser": "^0.0.1",
     "fzaninotto/faker": "^1.7",
     "symfony/event-dispatcher": "~3.4|~4.0"
   },


### PR DESCRIPTION
When installing on PHP 7, the deps will be taken at their highest compatible versions.