### PR TITLE
require explicit 'ifsnop/mysqldump-php' cause above version 2.7 it do…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "A drop-in replacement for mysqldump that optionally sanitizes DB fields for better GDPR conformity.",
   "require": {
     "symfony/console": "^3.0",
-    "ifsnop/mysqldump-php": "dev-master",
+    "ifsnop/mysqldump-php": "2.7.*",
     "cweagans/composer-patches": "^1.6",
     "bomoko/mysql-cnf-parser": "^0.0.2",
     "fzaninotto/faker": "^1.7",


### PR DESCRIPTION
require explicit 'ifsnop/mysqldump-php' cause above version 2.7 it do…
#47 