### PR TITLE
Add new parameter --gdpr-replacements-locale

### DIFF
--- a/src/ColumnTransformer/ColumnTransformer.php
+++ b/src/ColumnTransformer/ColumnTransformer.php
@@ -20,22 +20,22 @@ abstract class ColumnTransformer
     protected static $dispatcher;
 
 
-    public static function setUp()
+    public static function setUp($locale)
     {
         if (!isset(self::$dispatcher)) {
             self::$dispatcher = new EventDispatcher();
 
             self::$dispatcher->addListener(self::COLUMN_TRANSFORM_REQUEST,
-              new FakerColumnTransformer());
+              new FakerColumnTransformer($locale));
             self::$dispatcher->addListener(self::COLUMN_TRANSFORM_REQUEST,
               new ClearColumnTransformer());
         }
 
     }
 
-    public static function replaceValue($tableName, $columnName, $expression)
+    public static function replaceValue($tableName, $columnName, $expression, $locale)
     {
-        self::setUp();
+        self::setUp($locale);
         $event = new ColumnTransformEvent($tableName, $columnName, $expression);
         self::$dispatcher->dispatch(self::COLUMN_TRANSFORM_REQUEST, $event);
         if ($event->isReplacementSet()) {

--- a/src/ColumnTransformer/Plugins/FakerColumnTransformer.php
+++ b/src/ColumnTransformer/Plugins/FakerColumnTransformer.php
@@ -26,10 +26,10 @@ class FakerColumnTransformer extends ColumnTransformer
         return array_keys(self::$formatterTansformerMap);
     }
 
-    public function __construct()
+    public function __construct($locale)
     {
         if (!isset(self::$generator)) {
-            self::$generator = Factory::create();
+            self::$generator = Factory::create($locale);
             foreach(self::$generator->getProviders() as $provider)
             {
                 $clazz = new \ReflectionClass($provider);

--- a/src/Command/DumpCommand.php
+++ b/src/Command/DumpCommand.php
@@ -109,6 +109,8 @@ class DumpCommand extends Command
                 'A json of gdpr replacement values keyed by table and column.')
             ->addOption('gdpr-replacements-file', null, InputOption::VALUE_OPTIONAL,
                 'File that contains a json of gdpr replacement values keyed by table and column.')
+            ->addOption('gdpr-replacements-locale', null, InputOption::VALUE_OPTIONAL,
+                'Locale used for creating the fake data.')
             ->addOption('debug-sql', null, InputOption::VALUE_NONE,
                 'Add a comment with the dump sql.')
             // This seems NOT to work as documented.
@@ -371,6 +373,7 @@ class DumpCommand extends Command
             ] + [
                 'gdpr-expressions' => null,
                 'gdpr-replacements' => null,
+                'gdpr-replacements-locale' => 'en_EN',
                 'debug-sql' => false,
             ];
     }

--- a/src/MysqldumpGdpr.php
+++ b/src/MysqldumpGdpr.php
@@ -15,6 +15,9 @@ class MysqldumpGdpr extends Mysqldump
     /** @var [string][string]string */
     protected $gdprReplacements;
 
+    /** @var string */
+    protected $gdprReplacementsLocale;
+
     /** @var bool */
     protected $debugSql;
 
@@ -33,6 +36,11 @@ class MysqldumpGdpr extends Mysqldump
         if (array_key_exists('gdpr-replacements', $dumpSettings)) {
             $this->gdprReplacements = $dumpSettings['gdpr-replacements'];
             unset($dumpSettings['gdpr-replacements']);
+        }
+
+        if (array_key_exists('gdpr-replacements-locale', $dumpSettings)) {
+            $this->gdprReplacementsLocale = $dumpSettings['gdpr-replacements-locale'];
+            unset($dumpSettings['gdpr-replacements-locale']);
         }
 
         if (array_key_exists('debug-sql', $dumpSettings)) {
@@ -64,7 +72,7 @@ class MysqldumpGdpr extends Mysqldump
     protected function hookTransformColumnValue($tableName, $colName, $colValue)
     {
         if (!empty($this->gdprReplacements[$tableName][$colName])) {
-            $replacement = ColumnTransformer::replaceValue($tableName, $colName, $this->gdprReplacements[$tableName][$colName]);
+            $replacement = ColumnTransformer::replaceValue($tableName, $colName, $this->gdprReplacements[$tableName][$colName], $this->gdprReplacementsLocale);
             if($replacement !== FALSE) {
                 return $replacement;
             }


### PR DESCRIPTION
This adds a new parameter `--gdpr-replacements-locale` which will be passed down to the faker library, so one can generate more localized dumps.