### PR TITLE
fixes #52 Replace abandoned package fzaninotto/faker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,9 +5,10 @@
     "symfony/console": "^3.0",
     "ifsnop/mysqldump-php": "dev-master",
     "cweagans/composer-patches": "^1.6",
+    "symfony/event-dispatcher": "~3.4|~4.0",
+    "nette/finder": "2.5.2 as 3.0@dev",
     "bomoko/mysql-cnf-parser": "^0.0.2",
-    "fzaninotto/faker": "^1.7",
-    "symfony/event-dispatcher": "~3.4|~4.0"
+    "fakerphp/faker": "^1.14"
   },
   "license": "GPL-2.0-or-later",
   "authors": [


### PR DESCRIPTION
### Description

When installing with composer 2 you get warning:

``` bash
Package fzaninotto/faker is abandoned, you should avoid using it. No replacement was suggested.
```

### Solution
Replace abandoned package [fzaninotto/faker](https://github.com/fzaninotto/faker) with [fakerphp/faker](https://github.com/fakerphp/faker)


