### PR TITLE
Update bomoko/mysql-cnf-parser requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /vendor
 /composer.lock
 .idea
-gdpr-dump.code-workspace

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor
 /composer.lock
 .idea
+gdpr-dump.code-workspace

--- a/README.md
+++ b/README.md
@@ -106,3 +106,10 @@ Here we might need better options.
 ## Contributors notes
 
 * Note that the project follows [PSR-2](https://www.php-fig.org/psr/psr-2/) for formatting. 
+
+## Usage for CarePlanner
+
+```
+./mysqldump --user root --password --host host.co.uk --port 3306 --routines --gdpr-replacements-file ./gdpr-expressions.json CP2_anon > CP2_anon_anon.sql
+
+```

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "symfony/console": "^3.0",
     "ifsnop/mysqldump-php": "dev-master",
     "cweagans/composer-patches": "^1.6",
-    "bomoko/mysql-cnf-parser": "^0.0.2",
+    "bomoko/mysql-cnf-parser": "master",
     "fzaninotto/faker": "^1.7",
     "symfony/event-dispatcher": "~3.4|~4.0"
   },

--- a/gdpr-expressions.json
+++ b/gdpr-expressions.json
@@ -192,7 +192,7 @@
         "middle_name": {"formatter": "firstName"}
     },
     "users": {
-        "name": {"formatter": "name", "conditions": [
+        "name": {"formatter": "uniqueUsername", "conditions": [
             {
                 "operator": "!=",
                 "comparand": "admin"
@@ -206,5 +206,5 @@
         "mail": {"formatter": "email"},
         "init": {"formatter": "email"}
     }
-    
+
 }

--- a/gdpr-expressions.json
+++ b/gdpr-expressions.json
@@ -192,7 +192,17 @@
         "middle_name": {"formatter": "firstName"}
     },
     "users": {
-        "name": {"formatter": "md5"},
+        "name": {"formatter": "name", "conditions": [
+            {
+                "operator": "!=",
+                "comparand": "admin"
+            },
+            {
+                "operator": "!empty",
+                "comparand": null
+            }
+        ]
+        },
         "mail": {"formatter": "email"},
         "init": {"formatter": "email"}
     }

--- a/gdpr-expressions.json
+++ b/gdpr-expressions.json
@@ -1,0 +1,200 @@
+{
+    "activity": {
+        "message": {"formatter": "regex", "regexes":
+            [
+                {"regex": "/(<.*?>).*?(<\\/.*?>)/", "replacement": "$1XXXXX$2"},
+                {"regex": "/(pay rate for|invoice rate for|pay group for|invoice group for|charge method for|payment method for|actual start time for|actual end time for|the chargeable mileage for) (.*\\s+.*)\\s/i", "replacement": "$1 XXXXX XXXXX"},
+                {"regex": "/(by) .*?(on)/i", "replacement": "$1 XXXXX $2"},
+                {"regex": "/(was changed from) (.*) to (.*)/i", "replacement": "$1 XXXXXX to XXXXXX"},
+                {"regex": "/(was changed to) (.*)\\s/i", "replacement": "$1 XXXXXX "}
+            ]
+        }
+    },
+    "actual_times_received_extras": {
+        "value": {"formatter": "clear"}
+    },
+    "app_cp_log": {
+        "data": {"formatter": "clear"}
+    },
+    "app_cp_notes": {
+        "note": {"formatter": "text"}
+    },
+    "appointment_appointments": {
+        "notes": {"formatter": "text"},
+        "private_notes": {"formatter": "text"}
+    },
+    "appointment_archive": {
+        "notes": {"formatter": "text"},
+        "private_notes": {"formatter": "text"}
+    },
+    "appointment_instances": {
+        "notes": {"formatter": "text"},
+        "private_notes": {"formatter": "text"}
+    },
+    "appointment_regions": {
+        "name": {"formatter": "county"},
+        "address": {"formatter": "address"},
+        "email": {"formatter": "email"}
+    },
+    "availability": {
+        "notes": {"formatter": "text"}
+    },
+    "availability_archive": {
+        "notes": {"formatter": "text"}
+    },
+    "availability_profile": {
+        "notes": {"formatter": "text"}
+    },
+    "caretracker_message_log": {
+        "message": {"formatter": "text"}
+    },
+    "cm2000_data_received": {
+        "dump": {"formatter": "clear"}
+    },
+    "comment": {
+        "name": {"formatter": "name"}
+    },
+    "contacts": {
+        "forename": {"formatter": "firstName"},
+        "surname": {"formatter": "lastName"},
+        "address": {"formatter": "address"},
+        "postcode": {"formatter": "postcode"},
+        "home": {"formatter": "phoneNumber"},
+        "mobile": {"formatter": "mobileNumber"},
+        "work": {"formatter": "phoneNumber"},
+        "email": {"formatter": "email"},
+        "fax": {"formatter": "phoneNumber"},
+        "org_name": {"formatter": "company"},
+        "comments": {"formatter": "text"},
+        "additional_email": {"formatter": "email"}
+    },
+    "diary": {
+        "entry_body": {"formatter": "text"}
+    },
+    "diary_archive": {
+        "entry_body": {"formatter": "text"}
+    },
+    "email_addresses": {
+        "email": {"formatter": "email"}
+    },
+    "emailing_bounches": {
+        "email_address": {"formatter": "email"}
+    },
+    "emailing_log": {
+        "recipient_email": {"formatter": "email"},
+        "subject": {"formatter": "text"},
+        "body": {"formatter": "clear"}
+    },
+    "emailing_sets": {
+        "email": {"formatter": "clear"}
+    },
+    "field_data_comment_body": {
+        "comment_body_value": {"formatter": "clear"}
+    },
+    "field_revision_data_comment_body": {
+        "comment_body_value": {"formatter": "clear"}
+    },
+    "finance_export_customer_mappings": {
+        "accounts_package_customer_code": {"formatter": "word"},
+        "accounts_package_customer_code_description": {"formatter": "text"}
+    },
+    "finance_invoice_extras": {
+        "description": {"formatter": "word"}
+    },
+    "finance_invoice_extras_archive": {
+        "description": {"formatter": "word"}
+    },
+    "finance_organisations": {
+        "forename": {"formatter": "firstName"},
+        "surname": {"formatter": "lastName"},
+        "address": {"formatter": "address"},
+        "postcode": {"formatter": "postcode"},
+        "work": {"formatter": "phoneNumber"},
+        "mobile": {"formatter": "mobileNumber"},
+        "email": {"formatter": "email"}
+    },
+    "finance_organisations_archive": {
+        "forename": {"formatter": "firstName"},
+        "surname": {"formatter": "lastName"},
+        "address": {"formatter": "address"},
+        "postcode": {"formatter": "postcode"},
+        "work": {"formatter": "phoneNumber"},
+        "mobile": {"formatter": "mobileNumber"},
+        "email": {"formatter": "email"}
+    },
+    "human_resources": {
+        "notes": {"formatter": "text"},
+        "leaving_notes": {"formatter": "text"},
+        "dbs_number": {"formatter": "randomNumber"},
+        "national_insurance_number": {"formatter": "swiftBicNumber"},
+        "nhs_ref": {"formatter": "randomNumber"},
+        "payroll": {"formatter": "randomNumber"},
+        "social_services_ref": {"formatter": "swiftBicNumber"},
+        "financial_notes": {"formatter": "clear"},
+        "agent_ref": {"formatter": "clear"}
+    },
+    "login_details": {
+        "username": {"formatter": "name"},
+        "ip_address": {"formatter": "ipv4"},
+        "user_agent": {"formatter": "userAgent"}
+    },
+    "mar_charts_medication_client": {
+        "notes": {"formatter": "text"}
+    },
+    "mar_charts_medication_client_archive": {
+        "notes": {"formatter": "text"}
+    },
+    "mar_charts_medication_given": {
+        "response_notes": {"formatter": "text"}
+    },
+    "mar_charts_medication_given_archive": {
+        "response_notes": {"formatter": "text"}
+    },
+    "medication_notes": {
+        "notes": {"formatter": "text"}
+    },
+    "notices_cp": {
+        "subject": {"formatter": "text"},
+        "message": {"formatter": "text"}
+    },
+    "profile_value": {
+        "value": {"formatter": "clear"}
+    },
+    "respite": {
+        "notes": {"formatter": "text"}
+    },
+    "respite_archive": {
+        "notes": {"formatter": "text"}
+    },
+    "sms_track": {
+        "message": {"formatter": "text"}
+    },
+    "training": {
+        "notes": {"formatter": "text"}
+    },
+    "training_archive": {
+        "notes": {"formatter": "text"}
+    },
+    "user_communication_preferences": {
+        "invoice_address": {"formatter": "address"}
+    },
+    "user_fields": {
+        "forename": {"formatter": "firstName"},
+        "surname": {"formatter": "lastName"},
+        "address": {"formatter": "address"},
+        "mobile_number": {"formatter": "mobileNumber"},
+        "personal_phone_number": {"formatter": "mobileNumber"},
+        "landline_number": {"formatter": "phoneNumber"},
+        "postcode": {"formatter": "postcode"},
+        "preferred_alias": {"formatter": "firstName"},
+        "keysafe": {"formatter": "randomNumber"},
+        "entry_notes": {"formatter": "text"},
+        "middle_name": {"formatter": "firstName"}
+    },
+    "users": {
+        "name": {"formatter": "md5"},
+        "mail": {"formatter": "email"},
+        "init": {"formatter": "email"}
+    }
+    
+}

--- a/src/ColumnTransformer/ColumnTransformEvent.php
+++ b/src/ColumnTransformer/ColumnTransformEvent.php
@@ -9,16 +9,18 @@ class ColumnTransformEvent extends Event
 {
     protected $table;
     protected $column;
+    protected $value;
     protected $expression;
     protected $isReplacementSet = FALSE;
     protected $replacementValue;
     /**
      * ColumnTransformEvent constructor.
      */
-    public function __construct($table, $column, $expression)
+    public function __construct($table, $column, $value, $expression)
     {
         $this->table = $table;
         $this->column = $column;
+        $this->value = $value;
         $this->expression = $expression;
     }
 
@@ -31,6 +33,11 @@ class ColumnTransformEvent extends Event
     public function getTable()
     {
         return $this->table;
+    }
+
+    public function getValue()
+    {
+        return $this->value;
     }
 
     public function getColumn()

--- a/src/ColumnTransformer/ColumnTransformer.php
+++ b/src/ColumnTransformer/ColumnTransformer.php
@@ -5,6 +5,7 @@ namespace machbarmacher\GdprDump\ColumnTransformer;
 
 use machbarmacher\GdprDump\ColumnTransformer\Plugins\ClearColumnTransformer;
 use machbarmacher\GdprDump\ColumnTransformer\Plugins\FakerColumnTransformer;
+use machbarmacher\GdprDump\ColumnTransformer\Plugins\VerbatimColumnTransformer;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 abstract class ColumnTransformer
@@ -30,6 +31,7 @@ abstract class ColumnTransformer
             self::$dispatcher = new EventDispatcher();
             self::addTransformer(new FakerColumnTransformer());
             self::addTransformer(new ClearColumnTransformer());
+            self::addTransformer(new VerbatimColumnTransformer());
         }
     }
 

--- a/src/ColumnTransformer/ColumnTransformer.php
+++ b/src/ColumnTransformer/ColumnTransformer.php
@@ -7,6 +7,7 @@ use machbarmacher\GdprDump\ColumnTransformer\Plugins\ClearColumnTransformer;
 use machbarmacher\GdprDump\ColumnTransformer\Plugins\FakerColumnTransformer;
 use machbarmacher\GdprDump\ColumnTransformer\Plugins\VerbatimColumnTransformer;
 use machbarmacher\GdprDump\ColumnTransformer\Plugins\RegexColumnTransformer;
+use machbarmacher\GdprDump\ColumnTransformer\Plugins\UniqueUserNameColumnTransformer;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 abstract class ColumnTransformer
@@ -34,6 +35,7 @@ abstract class ColumnTransformer
             self::addTransformer(new ClearColumnTransformer());
             self::addTransformer(new VerbatimColumnTransformer());
             self::addTransformer(new RegexColumnTransformer());
+            self::addTransformer(new UniqueUsernameColumnTransformer());
         }
     }
 

--- a/src/ColumnTransformer/ColumnTransformer.php
+++ b/src/ColumnTransformer/ColumnTransformer.php
@@ -6,6 +6,7 @@ namespace machbarmacher\GdprDump\ColumnTransformer;
 use machbarmacher\GdprDump\ColumnTransformer\Plugins\ClearColumnTransformer;
 use machbarmacher\GdprDump\ColumnTransformer\Plugins\FakerColumnTransformer;
 use machbarmacher\GdprDump\ColumnTransformer\Plugins\VerbatimColumnTransformer;
+use machbarmacher\GdprDump\ColumnTransformer\Plugins\RegexColumnTransformer;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 abstract class ColumnTransformer
@@ -32,6 +33,7 @@ abstract class ColumnTransformer
             self::addTransformer(new FakerColumnTransformer());
             self::addTransformer(new ClearColumnTransformer());
             self::addTransformer(new VerbatimColumnTransformer());
+            self::addTransformer(new RegexColumnTransformer());
         }
     }
 

--- a/src/ColumnTransformer/ColumnTransformer.php
+++ b/src/ColumnTransformer/ColumnTransformer.php
@@ -33,10 +33,10 @@ abstract class ColumnTransformer
         }
     }
 
-    public static function replaceValue($tableName, $columnName, $expression)
+    public static function replaceValue($tableName, $columnName, $columnValue, $expression)
     {
         self::setUp();
-        $event = new ColumnTransformEvent($tableName, $columnName, $expression);
+        $event = new ColumnTransformEvent($tableName, $columnName, $columnValue, $expression);
         self::$dispatcher->dispatch(self::COLUMN_TRANSFORM_REQUEST, $event);
         if ($event->isReplacementSet()) {
             return $event->getReplacementValue();

--- a/src/ColumnTransformer/Plugins/ClearColumnTransformer.php
+++ b/src/ColumnTransformer/Plugins/ClearColumnTransformer.php
@@ -3,6 +3,7 @@
 namespace machbarmacher\GdprDump\ColumnTransformer\Plugins;
 
 use machbarmacher\GdprDump\ColumnTransformer\ColumnTransformer;
+use machbarmacher\GdprDump\ColumnTransformer\ColumnTransformEvent;
 
 class ClearColumnTransformer extends ColumnTransformer
 {
@@ -12,7 +13,7 @@ class ClearColumnTransformer extends ColumnTransformer
         return ['clear'];
     }
 
-    public function getValue($expression)
+    public function getValue(ColumnTransformEvent $event)
     {
         return "";
     }

--- a/src/ColumnTransformer/Plugins/FakerColumnTransformer.php
+++ b/src/ColumnTransformer/Plugins/FakerColumnTransformer.php
@@ -29,15 +29,10 @@ class FakerColumnTransformer extends ColumnTransformer
     public function __construct()
     {
         if (!isset(self::$generator)) {
-<<<<<<< HEAD
             $locale = substr($_SERVER['LANG'], 0, 5);
             self::$generator = Factory::create($locale);
             foreach(self::$generator->getProviders() as $provider)
             {
-=======
-            self::$generator = Factory::create();
-            foreach (self::$generator->getProviders() as $provider) {
->>>>>>> ca76d2d1d465f7bf4b9168f505a1120b7ea2d543
                 $clazz = new \ReflectionClass($provider);
                 $methods = $clazz->getMethods(\ReflectionMethod::IS_PUBLIC);
                 foreach ($methods as $m) {

--- a/src/ColumnTransformer/Plugins/FakerColumnTransformer.php
+++ b/src/ColumnTransformer/Plugins/FakerColumnTransformer.php
@@ -3,8 +3,8 @@
 namespace machbarmacher\GdprDump\ColumnTransformer\Plugins;
 
 use Faker\Factory;
-use Faker\Provider\Base;
 use machbarmacher\GdprDump\ColumnTransformer\ColumnTransformer;
+use machbarmacher\GdprDump\ColumnTransformer\ColumnTransformEvent;
 
 class FakerColumnTransformer extends ColumnTransformer
 {
@@ -30,21 +30,21 @@ class FakerColumnTransformer extends ColumnTransformer
     {
         if (!isset(self::$generator)) {
             self::$generator = Factory::create();
-            foreach(self::$generator->getProviders() as $provider)
-            {
+            foreach (self::$generator->getProviders() as $provider) {
                 $clazz = new \ReflectionClass($provider);
                 $methods = $clazz->getMethods(\ReflectionMethod::IS_PUBLIC);
-                foreach($methods as $m)
-                {
-                    if(strpos($m->name, '__') === 0) continue;
+                foreach ($methods as $m) {
+                    if (strpos($m->name, '__') === 0) {
+                        continue;
+                    }
                     self::$formatterTansformerMap[$m->name] = $m->name;
                 }
             }
         }
     }
 
-    public function getValue($expression)
+    public function getValue(ColumnTransformEvent $event)
     {
-        return self::$generator->format(self::$formatterTansformerMap[$expression['formatter']]);
+        return self::$generator->format(self::$formatterTansformerMap[$event->getExpression()['formatter']]);
     }
 }

--- a/src/ColumnTransformer/Plugins/FakerColumnTransformer.php
+++ b/src/ColumnTransformer/Plugins/FakerColumnTransformer.php
@@ -29,7 +29,8 @@ class FakerColumnTransformer extends ColumnTransformer
     public function __construct()
     {
         if (!isset(self::$generator)) {
-            self::$generator = Factory::create();
+            $locale = substr($_SERVER['LANG'], 0, 5);
+            self::$generator = Factory::create($locale);
             foreach(self::$generator->getProviders() as $provider)
             {
                 $clazz = new \ReflectionClass($provider);

--- a/src/ColumnTransformer/Plugins/RegexColumnTransformer.php
+++ b/src/ColumnTransformer/Plugins/RegexColumnTransformer.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace machbarmacher\GdprDump\ColumnTransformer\Plugins;
+
+use machbarmacher\GdprDump\ColumnTransformer\ColumnTransformer;
+use machbarmacher\GdprDump\ColumnTransformer\ColumnTransformEvent;
+
+class RegexColumnTransformer extends ColumnTransformer
+{
+
+    protected function getSupportedFormatters()
+    {
+        return ['regex'];
+    }
+
+    public function getValue(ColumnTransformEvent $event)
+    {
+        $existing_column_value = $event->getValue();
+        $regexes = $event->getExpression()['regexes'];
+        foreach ($regexes as $regex_operation) {
+            error_log(print_r($regex_operation, TRUE));
+            $existing_column_value = preg_replace($regex_operation['regex'], $regex_operation['replacement'], $existing_column_value);
+        }
+        return $existing_column_value;
+    }
+}

--- a/src/ColumnTransformer/Plugins/RegexColumnTransformer.php
+++ b/src/ColumnTransformer/Plugins/RegexColumnTransformer.php
@@ -18,7 +18,6 @@ class RegexColumnTransformer extends ColumnTransformer
         $existing_column_value = $event->getValue();
         $regexes = $event->getExpression()['regexes'];
         foreach ($regexes as $regex_operation) {
-            error_log(print_r($regex_operation, TRUE));
             $existing_column_value = preg_replace($regex_operation['regex'], $regex_operation['replacement'], $existing_column_value);
         }
         return $existing_column_value;

--- a/src/ColumnTransformer/Plugins/UniqueUserNameColumnTransformer.php
+++ b/src/ColumnTransformer/Plugins/UniqueUserNameColumnTransformer.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace machbarmacher\GdprDump\ColumnTransformer\Plugins;
+
+use Faker\Factory;
+use machbarmacher\GdprDump\ColumnTransformer\ColumnTransformer;
+use machbarmacher\GdprDump\ColumnTransformer\ColumnTransformEvent;
+
+class UniqueUsernameColumnTransformer extends ColumnTransformer
+{
+
+    private static $generator;
+    private static $nameCache = [];
+
+    protected function getSupportedFormatters()
+    {
+        return ['uniqueUsername'];
+    }
+
+    public function __construct()
+    {
+        if (!isset(self::$generator)) {
+            $locale = substr($_SERVER['LANG'], 0, 5);
+            self::$generator = Factory::create($locale);
+        }
+    }
+
+    public function getValue(ColumnTransformEvent $event)
+    {
+        $temp_name = self::$generator->format('name');
+        while (isset(self::$nameCache[$temp_name])) {
+            $temp_name = $this->uniquify($temp_name);
+        }
+        self::$nameCache[$temp_name] = TRUE;
+        return $temp_name;
+    }
+
+    private function uniquify($name) {
+        return $name .= rand(0,1000);
+    }
+}

--- a/src/ColumnTransformer/Plugins/VerbatimColumnTransformer.php
+++ b/src/ColumnTransformer/Plugins/VerbatimColumnTransformer.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace machbarmacher\GdprDump\ColumnTransformer\Plugins;
+
+use machbarmacher\GdprDump\ColumnTransformer\ColumnTransformer;
+use machbarmacher\GdprDump\ColumnTransformer\ColumnTransformEvent;
+
+class VerbatimColumnTransformer extends ColumnTransformer
+{
+
+    protected function getSupportedFormatters()
+    {
+        return ['verbatim'];
+    }
+
+    public function getValue(ColumnTransformEvent $event)
+    {
+        return $event->getExpression()['value'];
+    }
+}

--- a/src/Command/DumpCommand.php
+++ b/src/Command/DumpCommand.php
@@ -181,6 +181,7 @@ class DumpCommand extends Command
                 'user',
                 'host',
                 'port',
+                'password',
                 'socket',
                 'db-name',
                 'db-type',

--- a/src/MysqldumpGdpr.php
+++ b/src/MysqldumpGdpr.php
@@ -44,14 +44,16 @@ class MysqldumpGdpr extends Mysqldump
         $this->setTransformColumnValueHook(
             function ($tableName, $colName, $colValue, $row) {
                 if (!empty($this->gdprReplacements[$tableName][$colName])) {
-                    $replacement = ColumnTransformer::replaceValue(
+                    if ($this->replacementConditionsMet($this->gdprReplacements[$tableName][$colName], $colValue)) {
+                        $replacement = ColumnTransformer::replaceValue(
                         $tableName,
                         $colName,
                         $colValue,
                         $this->gdprReplacements[$tableName][$colName]
                     );
-                    if ($replacement !== false) {
-                        return $replacement;
+                        if ($replacement !== false) {
+                            return $replacement;
+                        }
                     }
                 }
 
@@ -80,5 +82,65 @@ class MysqldumpGdpr extends Mysqldump
         }
 
         return $columnStmt;
+    }
+
+    /**
+     * Check if any conditions are set for a replacement.
+     * 
+     * If conditions are present, return TRUE if they are met, or FALSE if any
+     * one of them is not met.
+     *
+     * @param [array] $replacement_details Array of replacement information
+     *  taken from gdpr_replacements JSON file.
+     * @param mixed $current_value Current value of column
+     * @return bool
+     */
+    private function replacementConditionsMet($replacement_details, $current_value) {
+        
+        // Early bailout
+        if (empty($replacement_details['conditions'])) {
+            return TRUE;
+        }
+
+        $evaluation = FALSE;
+
+        foreach ($replacement_details['conditions'] as $condition) {
+            $comparand = $condition['comparand'];
+            $operator = $condition['operator'];
+            switch ($operator) {
+                case '=':
+                $evaluation = $comparand == $current_value;
+                break;
+
+                case '!=':
+                $evaluation = $comparand != $current_value;
+                break;
+
+                case 'empty':
+                $evaluation = empty($current_value);
+                break;
+
+                case '!empty':
+                $evaluation = !empty($current_value);
+                break;
+
+                case '<';
+                $evaluation = $current_value < $comparand;
+                break;
+
+                case '>';
+                $evaluation = $current_value > $comparand;
+                break;
+
+                default:
+                throw new Exception('Unsupported operand: ' . $operator);
+                break;
+            }
+            
+            if ($evaluation === FALSE) {
+                return FALSE;
+            }
+        }
+        return $evaluation;
     }
 }

--- a/src/MysqldumpGdpr.php
+++ b/src/MysqldumpGdpr.php
@@ -47,6 +47,7 @@ class MysqldumpGdpr extends Mysqldump
                     $replacement = ColumnTransformer::replaceValue(
                         $tableName,
                         $colName,
+                        $colValue,
                         $this->gdprReplacements[$tableName][$colName]
                     );
                     if ($replacement !== false) {

--- a/src/MysqldumpGdpr.php
+++ b/src/MysqldumpGdpr.php
@@ -86,7 +86,7 @@ class MysqldumpGdpr extends Mysqldump
 
     /**
      * Check if any conditions are set for a replacement.
-     * 
+     *
      * If conditions are present, return TRUE if they are met, or FALSE if any
      * one of them is not met.
      *
@@ -96,7 +96,7 @@ class MysqldumpGdpr extends Mysqldump
      * @return bool
      */
     private function replacementConditionsMet($replacement_details, $current_value) {
-        
+
         // Early bailout
         if (empty($replacement_details['conditions'])) {
             return TRUE;
@@ -133,10 +133,10 @@ class MysqldumpGdpr extends Mysqldump
                 break;
 
                 default:
-                throw new Exception('Unsupported operand: ' . $operator);
+                throw new \Exception('Unsupported operand: ' . $operator);
                 break;
             }
-            
+
             if ($evaluation === FALSE) {
                 return FALSE;
             }


### PR DESCRIPTION
- bomoko/mysql-cnf-parser master now has "nette/finder": "^2.5 || ^3.0@dev", allowing this to work on PHP 7.x.
- 0.0.2 required "nette/finder": "^3.0@dev" which required "php": ">=8.0 <8.1"
- the update hasn't been tagged yet so may want to adjust this once the tag is added.